### PR TITLE
Updated workflow json files with correct node version numbers

### DIFF
--- a/workflows/tinyterra_imagebash.json
+++ b/workflows/tinyterra_imagebash.json
@@ -90,7 +90,7 @@
       "properties": {
         "Node name for S&R": "ttN pipeOUT",
         "ttNbgOverride": "",
-        "ttNnodeVersion": "1.0.0"
+        "ttNnodeVersion": "1.1.0"
       },
       "color": "#222",
       "bgcolor": "#000"
@@ -183,7 +183,7 @@
       "properties": {
         "Node name for S&R": "ttN pipeOUT",
         "ttNbgOverride": "",
-        "ttNnodeVersion": "1.0.0"
+        "ttNnodeVersion": "1.1.0"
       },
       "color": "#222",
       "bgcolor": "#000"
@@ -272,7 +272,7 @@
       "properties": {
         "Node name for S&R": "ttN pipeOUT",
         "ttNbgOverride": "",
-        "ttNnodeVersion": "1.0.0"
+        "ttNnodeVersion": "1.1.0"
       },
       "color": "#222",
       "bgcolor": "#000"
@@ -364,7 +364,7 @@
       "properties": {
         "Node name for S&R": "ttN pipeOUT",
         "ttNbgOverride": "",
-        "ttNnodeVersion": "1.0.0"
+        "ttNnodeVersion": "1.1.0"
       },
       "color": "#222",
       "bgcolor": "#000"
@@ -502,7 +502,7 @@
       ],
       "properties": {
         "Node name for S&R": "ttN pipeKSampler",
-        "ttNnodeVersion": "1.0.0"
+        "ttNnodeVersion": "1.0.3"
       },
       "widgets_values": [
         "None",
@@ -696,7 +696,7 @@
       ],
       "properties": {
         "Node name for S&R": "ttN pipeKSampler",
-        "ttNnodeVersion": "1.0.0"
+        "ttNnodeVersion": "1.0.3"
       },
       "widgets_values": [
         "None",
@@ -907,7 +907,7 @@
       "properties": {
         "infoWidgetHidden": false,
         "Node name for S&R": "ttN hiresfixScale",
-        "ttNnodeVersion": "1.0.0"
+        "ttNnodeVersion": "1.0.2"
       },
       "widgets_values": [
         "DF2K_JPEG.pth",
@@ -1001,7 +1001,7 @@
       "properties": {
         "Node name for S&R": "ttN pipeLoader",
         "ttNbgOverride": "",
-        "ttNnodeVersion": "1.0.0"
+        "ttNnodeVersion": "1.0.1"
       },
       "widgets_values": [
         "Good\\deliberate_v2.safetensors",
@@ -1335,7 +1335,7 @@
       ],
       "properties": {
         "Node name for S&R": "ttN pipeKSampler",
-        "ttNnodeVersion": "1.0.0"
+        "ttNnodeVersion": "1.0.3"
       },
       "widgets_values": [
         "add_detail.safetensors",

--- a/workflows/tinyterra_trueHRFix.json
+++ b/workflows/tinyterra_trueHRFix.json
@@ -132,7 +132,7 @@
       ],
       "properties": {
         "Node name for S&R": "ttN pipeKSampler",
-        "ttNnodeVersion": "1.0.0"
+        "ttNnodeVersion": "1.0.3"
       },
       "widgets_values": [
         "add_detail.safetensors",
@@ -224,7 +224,7 @@
       ],
       "properties": {
         "Node name for S&R": "ttN pipeLoader",
-        "ttNnodeVersion": "1.0.0"
+        "ttNnodeVersion": "1.0.1"
       },
       "widgets_values": [
         "dreamshaper_6NoVae.safetensors",
@@ -302,7 +302,7 @@
       "properties": {
         "infoWidgetHidden": false,
         "Node name for S&R": "ttN hiresfixScale",
-        "ttNnodeVersion": "1.0.0"
+        "ttNnodeVersion": "1.0.2"
       },
       "widgets_values": [
         "DF2K_JPEG.pth",
@@ -459,7 +459,7 @@
       ],
       "properties": {
         "Node name for S&R": "ttN pipeKSampler",
-        "ttNnodeVersion": "1.0.0"
+        "ttNnodeVersion": "1.0.3"
       },
       "widgets_values": [
         "None",

--- a/workflows/tinyterra_xyPlot.json
+++ b/workflows/tinyterra_xyPlot.json
@@ -112,7 +112,7 @@
       ],
       "properties": {
         "Node name for S&R": "ttN pipeLoader",
-        "ttNnodeVersion": "1.0.0"
+        "ttNnodeVersion": "1.0.1"
       },
       "widgets_values": [
         "dreamshaper_6NoVae.safetensors",
@@ -272,7 +272,7 @@
       ],
       "properties": {
         "Node name for S&R": "ttN pipeKSampler",
-        "ttNnodeVersion": "1.0.0"
+        "ttNnodeVersion": "1.0.3"
       },
       "widgets_values": [
         "None",


### PR DESCRIPTION
When I tried out the new nodes and loaded the sample workflows, everything was loading as RED for incorrect version numbers. Doing a "reload node" fixes it... but disconnects everything.

Went through and updated the workflows with the current versions as of this commit. Workflow json files should load and run without needing to go back in and fix.