### PR TITLE
Fix exception when retrieving node info for ttN_conditioning

### DIFF
--- a/ttNpy/tinyterraNodes.py
+++ b/ttNpy/tinyterraNodes.py
@@ -2259,7 +2259,7 @@ class ttN_conditioning:
                     "prepend_positive": ("STRING", {"default": None, "forceInput": True}),
                     "prepend_negative": ("STRING", {"default": None, "forceInput": True}),
                     },
-                "hidden": {"ttNnodeVersion": ttN_conditioning.version}, "my_unique_id": "UNIQUE_ID",}
+                "hidden": {"ttNnodeVersion": ttN_conditioning.version, "my_unique_id": "UNIQUE_ID"},}
 
     RETURN_TYPES = ("MODEL", "CONDITIONING", "CONDITIONING", "CLIP", "STRING", "STRING")
     RETURN_NAMES = ("model", "positive", "negative", "clip", "pos_string", "neg_string")


### PR DESCRIPTION
my_unique_id was outside the "hidden" dictionary.

This seems unintended and causes an exception when retrieving node info since the code expects all values to be dictionaries.

It might be that it's just *my* version of ComfyUI (quite heavily patched) that actually throws the exception if this hasn't been caught before, but this is still clearly a bug.
