### PR TITLE
Declare placeholder variable

### DIFF
--- a/js/ttNinterface.js
+++ b/js/ttNinterface.js
@@ -400,7 +400,7 @@ app.registerExtension({
     },
 
     beforeRegisterNodeDef(nodeType, nodeData, app) {
-	originalGetSlotMenuOptions = nodeType.prototype.getSlotMenuOptions;
+	    const originalGetSlotMenuOptions = nodeType.prototype.getSlotMenuOptions;
         nodeType.prototype.getSlotMenuOptions = (slot) => {
 	    originalGetSlotMenuOptions?.apply(this, slot);
             let menu_info = [];


### PR DESCRIPTION
Address strict-mode ReferenceError. Introduced in https://github.com/TinyTerra/ComfyUI_tinyterraNodes/commit/348f5da29e9af498c396605d60f179ce1fd2a24c