### PR TITLE
Fix issue when warning inside enConcatConditioning

### DIFF
--- a/ttNpy/tinyterraNodes.py
+++ b/ttNpy/tinyterraNodes.py
@@ -2061,7 +2061,7 @@ class ttN_pipeEncodeConcat:
             conditioning_to = [[conditioning_to, {"pooled_output": pooled}]]
 
             if len(conditioning_from) > 1:
-                ttNl.warn("encode and concat conditioning_from contains more than 1 cond, only the first one will actually be applied to conditioning_to")
+                ttNl("encode and concat conditioning_from contains more than 1 cond, only the first one will actually be applied to conditioning_to").t(f'pipeEncodeConcat[{my_unique_id}]').warn().p()
 
             cond_from = conditioning_from[0][0]
 


### PR DESCRIPTION
Otherwise...
```
    self.label_value = f'{CC.RED}Warning:{CC.LIGHTRED} '
AttributeError: 'str' object has no attribute 'label_value'
```