### PR TITLE
Fix ttN KSampler crash with Anima and other video-latent image models

### DIFF
--- a/ttNpy/tinyterraNodes.py
+++ b/ttNpy/tinyterraNodes.py
@@ -411,6 +411,7 @@ class ttNsampler:
 
     def common_ksampler(self, model, seed, steps, cfg, sampler_name, scheduler, positive, negative, latent, denoise=1.0, disable_noise=False, start_step=None, last_step=None, force_full_denoise=False, preview_latent=True, disable_pbar=False):
         latent_image = latent["samples"]
+        latent_image = comfy.sample.fix_empty_latent_channels(model, latent_image, latent.get("downscale_ratio_spacial", None))
 
         if disable_noise:
             noise = torch.zeros(latent_image.size(), dtype=latent_image.dtype, layout=latent_image.layout, device="cpu")


### PR DESCRIPTION
The tinyTerras KSampler implementation skips comfy.sample.fix_empty_latent_channels, which the stock ComfyUI sampler does use:
https://github.com/Comfy-Org/ComfyUI/blob/7c4d95d1bc2ef178937d203aa81070db0b172a92/nodes.py#L1527

Without it models that expect a 5-dimensional latent (Wan2.1 / Cosmos predict2 / Anima) will fail with error:
**Exception: tuple index out of range**

This fix solves that - now models like Anima can be loaded with no problem

Thanks for creating and maintaining this project, I really appreciate it and still use it no problems in 2026 - great tool, simple usage